### PR TITLE
Adjust Docker Compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,7 @@ services:
       - ~/docker/volumes/postgres:/var/lib/postgresql/data
     environment:
       - POSTGRES_PASSWORD=docker
+      - POSTGRES_USER=postgres
 #  borrel_jukebox:
 #    build:
 #      context: .
@@ -24,5 +25,5 @@ services:
       - '8080:8080'
     expose:
       - 8080
-#    depends_on:
-#      - borrel_jukebox
+    depends_on:
+      - borrel_database

--- a/src/flaskapp/Dockerfile
+++ b/src/flaskapp/Dockerfile
@@ -2,6 +2,8 @@ FROM python:3.7-slim
 
 # set correct timezone for scheduler
 ENV TZ Europe/Amsterdam
+ENV POSTGRES_USER=postgres
+ENV POSTGRES_PASSWORD=docker
 
 # set /app as working directory
 ENV APP_DIR /app
@@ -20,6 +22,6 @@ EXPOSE 8080
 # CMD ["python", "serve_gevent.py"]
 
 # Run with gunicorn
-ENTRYPOINT ["gunicorn", "--bind", "0.0.0.0:8080", "--workers", "4" , "--log-level", "debug", "src.flaskapp.app:app"]
+ENTRYPOINT ["gunicorn", "--bind", "0.0.0.0:8080", "--workers", "4" , "--log-level", "debug", "src.flaskapp.wsgi:app"]
 
 

--- a/src/flaskapp/__init__.py
+++ b/src/flaskapp/__init__.py
@@ -9,7 +9,7 @@ from src.flaskapp.extensions import db
 from src.flaskapp.config import *
 
 
-def create_app(ConfigObject=DevelopmentConfig):
+def create_app(ConfigObject=ProdConfig):
 
     env = os.environ.get('ENV')
     if ConfigObject:
@@ -19,7 +19,7 @@ def create_app(ConfigObject=DevelopmentConfig):
             config = ProdConfig
         elif env == 'testing':
             config = TestingConfig
-        else:
+        elif env == 'development':
             config = DevelopmentConfig
 
     app = Flask(__name__)

--- a/src/flaskapp/config.py
+++ b/src/flaskapp/config.py
@@ -22,7 +22,7 @@ class DevelopmentConfig(BaseConfig):
         'user': os.environ.get('POSTGRES_USER', 'postgres'),
         'pw': os.environ.get('POSTGRES_PASSWORD', 'docker'),
         'db': 'postgres',
-        'host': 'localhost',
+        'host': '0.0.0.0',
         'port': '5432',
     }
 
@@ -48,7 +48,7 @@ class ProdConfig(DevelopmentConfig):
         'user': os.environ.get('POSTGRES_USER'),
         'pw': os.environ.get('POSTGRES_PASSWORD'),
         'db': 'postgres',
-        'host': 'localhost',
+        'host': 'borrel_database',
         'port': '5432',
     }
 


### PR DESCRIPTION
Making the docker-compose compatible with the new set up by changing hostnames and retrieving the flask app from `wsgi.py` instead of from `app.py`.